### PR TITLE
Add sync-labels github workflow

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,0 +1,9 @@
+on: [issues, pull_request]
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    name: Sync repository labels
+    steps:
+      - uses: Financial-Times/rel-eng-labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why?

https://rer.in.ft.com, for prioritising issues, is powered by every repo having the same labels. This PR adds the github action that syncs labels to the standard rel-eng set.

## What?

Adds the github action file for Financial-Times/rel-eng-labels